### PR TITLE
Add rectangle example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ target_sources(hub75 PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/examples/analog_clock.cpp
         ${CMAKE_CURRENT_LIST_DIR}/examples/pixel_fill.hpp
         ${CMAKE_CURRENT_LIST_DIR}/examples/grey_scale_stripes.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/examples/rectangle.hpp
         ${CMAKE_CURRENT_LIST_DIR}/src/rul6024.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/fm6126a.cpp
         ${CMAKE_CURRENT_LIST_DIR}/examples/hue_value_spectrum.hpp

--- a/examples/rectangle.hpp
+++ b/examples/rectangle.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "libraries/pico_graphics/pico_graphics.hpp"
+#include <cstdint>
+
+using namespace pimoroni;
+
+class Rectangle : public PicoGraphics_PenRGB888
+{
+public:
+    explicit Rectangle(uint width = 64, uint height = 64) : PicoGraphics_PenRGB888(width, height, nullptr)
+    {
+        set_pen(0);
+        clear();
+        setIntensity(1.0);
+    }
+
+    void draw()
+    {
+        constexpr int max_width = DISPLAY_WIDTH - 1;
+        constexpr int max_height = DISPLAY_HEIGHT - 1;
+
+        // Draw four lines to form a rectangle around the screen. Each line has a unique color and ends one pixel short
+        // of the edge of the panel so it doesn't 'interfere' with the next line.
+        // (the pixel would be overwritten, but why draw it twice?)
+
+        // Top edge, horizontal: red
+        set_pen(0xFF0000);
+        line(Point(0, 0), Point(max_width, 0));
+        // Right edge, vertical: green
+        set_pen(0x00FF00);
+        line(Point(max_width, 0), Point(max_width, max_height)); // Why not max_height-1?  Maybe an issue with the graphics libraries line() function?
+        // Bottom edge, horizontal: blue
+        set_pen(0x0000FF);
+        line(Point(max_width + 1, max_height), Point(1, max_height)); // max_width+1 is needed to get the corner pixel lit up?
+        // Left edge, vertical: cyan
+        set_pen(0x00FFFF);
+        line(Point(0, max_height + 1), Point(0, 1)); // max_height+1 is needed to get the corner pixel lit up?
+
+        // Draw a cross inside the rectangle, reaching from corner to corner
+        // Top left to bottom right: yellow
+        set_pen(0xFFFF00);
+        line(Point(1, 1), Point(max_width, max_height));
+        // Bottom left to top right: white
+        set_pen(0xFFFFFF);
+        line(Point(1, max_height - 1), Point(max_width, 1)); // Why not max_width-1?
+    }
+};

--- a/hub75_demo.cpp
+++ b/hub75_demo.cpp
@@ -34,6 +34,7 @@
 #include "hue_value_spectrum.hpp"
 #include "pixel_fill.hpp"
 #include "grey_scale_stripes.hpp"
+#include "rectangle.hpp"
 
 static int demo_index = 0; ///< Example selector
 
@@ -90,7 +91,7 @@ int led_init(void)
  */
 bool skip_to_next_demo(__unused struct repeating_timer *t)
 {
-    if (++demo_index > 7)
+    if (++demo_index > 8)
     {
         demo_index = 0; // Cycle through all examples
     }
@@ -159,6 +160,8 @@ int main()
     PixelFill pixelFill = PixelFill(DISPLAY_WIDTH, DISPLAY_HEIGHT);
 
     GreyScaleStripes greyScaleStripes = GreyScaleStripes(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+
+    Rectangle rectangle = Rectangle(DISPLAY_WIDTH, DISPLAY_HEIGHT);
 
     // Cycle through the examples - move to next example every 15 seconds
     struct repeating_timer timer;
@@ -233,6 +236,11 @@ int main()
         {
             greyScaleStripes.drawStripes();
             update(&greyScaleStripes);
+        }
+        else if (demo_index == 8)
+        {
+            rectangle.draw();
+            update(&rectangle);
         }
 
         // matrix panel brightness will vary when you uncomment the following api call


### PR DESCRIPTION
Draw a rectangle around the display: top row in red, right column in green, bottom row in blue, left column cyan.
Additional, draw a yellow line from top left to bottom right corner and a white line from the top right to the bottom left corner.

This can help to debug pixel mappings for new panels or chains.