### PR TITLE
Allow compilation without picograpics

### DIFF
--- a/src/hub75.cpp
+++ b/src/hub75.cpp
@@ -972,7 +972,6 @@ static inline constexpr int rotated_src_index(int dx, int dy, int dw, int dh)
 #endif
 }
 
-#if USE_PICO_GRAPHICS == true
 // ---------------------------------------------------------------------------
 // Shared rotation-lookup helper
 //
@@ -998,6 +997,7 @@ static inline uint32_t rot_lut_rgb(const uint8_t *src, int dx_base, int dy, int 
     return LUT_MAPPING_RGB(src[rot + 2], src[rot + 1], src[rot]);
 }
 
+#if USE_PICO_GRAPHICS == true
 /**
  * @brief Update frame_buffer from PicoGraphics source (RGB888 / packed 32-bit),
  *


### PR DESCRIPTION
If `USE_PICOGRAPHICS` is not defined,  `rot_lut_rgb()` is hidden due to a preprocessor check. Move the check further down so that the function is always available.

An alternative would be to move the entire `rot_lut_rgb()` function further down, out of the `USE_PICOGRAPHICS` block to be compiled with `update_bgr()`, but I think having `rot_lut()` and `rot_lut_rgb()` close together makes more sense.