### PR TITLE
Simplify API and introduce rotation-aware HUB75_SCREEN_WITH/HEIGHT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ target_compile_definitions(hub75_demo PRIVATE
     CLK_PIN=11                  # GPIO pin for CLK - use pin 41 for PICO_RP2350B
     STROBE_PIN=12               # GPIO pin for STROBE (LATCH) - use pin 42 for PICO_RP2350B
     OEN_PIN=13                  # GPIO for OE pin - use pin 43 for PICO_RP2350B
-    PANEL=HUB75                 # 
+    PANEL=HUB75_DEFAULT         #
     PANEL_TYPE=PANEL_GENERIC    # select PANEL_TYPE
     INVERTED_STB=false          # inverted pin signal for OE (untested)
     SM_CLOCKDIV_FACTOR=1.0f     # to prevent flicker or ghosting it might be worth a try to reduce state machine speed

--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,8 @@ constexpr uint32_t DISPLAY_WIDTH  = MATRIX_PANEL_WIDTH  * CHAIN_COLS;
 constexpr uint32_t DISPLAY_HEIGHT = MATRIX_PANEL_HEIGHT * CHAIN_ROWS;
 ```
 
+The display dimensions are only used internally, use the [rotation-aware](#display-rotation) `HUB75_SCREEN_WIDTH` and `HUB75_SCREEN_HEIGHT` to initialize graphics libraries or allocate framebuffers.
+
 #### Chain Modes
 
 | Mode | Description |
@@ -1597,53 +1599,33 @@ Logical buffer:  depends on DISPLAY_ROTATION       (this is what YOU must size c
 
 ---
 
-### Source Buffer Dimensions per Rotation Value
+To help avoiding mistakes, the library provides the rotation-aware `HUB75_SCREEN_WIDTH` and `HUB75_SCREEN_HEIGHT` constants. They contain the current width and height of your logical screen.
 
-| `DISPLAY_ROTATION` | Source buffer width | Source buffer height |
+### Screen Dimensions per Rotation Value
+
+| `DISPLAY_ROTATION` | Screen width | Screen height |
 |---|---|---|
 | `0` | `DISPLAY_WIDTH` | `DISPLAY_HEIGHT` |
 | `90` | `DISPLAY_HEIGHT` | `DISPLAY_WIDTH` |
 | `180` | `DISPLAY_WIDTH` | `DISPLAY_HEIGHT` |
 | `270` | `DISPLAY_HEIGHT` | `DISPLAY_WIDTH` |
 
-Example: a `64×96` physical chain (`DISPLAY_WIDTH=64`, `DISPLAY_HEIGHT=96`) at `DISPLAY_ROTATION=90`
-needs a source buffer that is **96 pixels wide and 64 pixels tall** — not 64×96.
-
-180° keeps the same buffer shape as 0° (the image is simply flipped, not transposed), so it needs no
-special handling beyond setting the define.
-
 ---
 
 ### Setting Up the Source Buffer
 
-**`update_bgr()`** takes a raw byte buffer. Size it using the table above instead of always assuming
-`DISPLAY_WIDTH × DISPLAY_HEIGHT`:
+**`update_bgr()`** takes a raw byte buffer. Use the provided rotation-aware constants instead of `DISPLAY_WIDTH × DISPLAY_HEIGHT`:
 
 ```cpp
-#if DISPLAY_ROTATION == 90 || DISPLAY_ROTATION == 270
-constexpr uint32_t SRC_WIDTH  = DISPLAY_HEIGHT;
-constexpr uint32_t SRC_HEIGHT = DISPLAY_WIDTH;
-#else
-constexpr uint32_t SRC_WIDTH  = DISPLAY_WIDTH;
-constexpr uint32_t SRC_HEIGHT = DISPLAY_HEIGHT;
-#endif
-
-uint8_t src_buffer[SRC_WIDTH * SRC_HEIGHT * 3]; // BGR888
+uint8_t src_buffer[HUB75_SCREEN_WIDTH * HUB75_SCREEN_HEIGHT * 3]; // BGR888
 ```
+The underlying memory allocation stays the same, but the code gets much more readable. The graphics library can be initialized with the exact same constants as well:
 
-**`update()`** takes a `PicoGraphics` canvas. Construct it with the same swapped dimensions at
-`90°`/`270°`:
+**`update()`** takes a `PicoGraphics` canvas:
 
 ```cpp
-#if DISPLAY_ROTATION == 90 || DISPLAY_ROTATION == 270
-PicoGraphics_PenRGB888 graphics(DISPLAY_HEIGHT, DISPLAY_WIDTH, frame_buffer);
-#else
-PicoGraphics_PenRGB888 graphics(DISPLAY_WIDTH, DISPLAY_HEIGHT, frame_buffer);
-#endif
+PicoGraphics_PenRGB888 graphics(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT, frame_buffer);
 ```
-
-(Exact constructor signature depends on the graphics backend you use — the point is which value goes
-into *width* and which into *height*, not the specific class name.)
 
 ---
 
@@ -1653,21 +1635,7 @@ Rotation and serpentine chaining are independent and compose cleanly: `CHAIN_MOD
 handles the 180° per-panel correction needed for the physical U-turn cabling (see
 [How Serpentine Reversal Works Internally](#how-serpentine-reversal-works-internally)), while
 `DISPLAY_ROTATION` applies on top of that, to the display as a whole. You don't need to do anything
-differently for chained arrays beyond sizing your source buffer according to the table above, using
-the chain's derived `DISPLAY_WIDTH` / `DISPLAY_HEIGHT`.
-
----
-
-### Common Mistake — Why This Can Go Unnoticed
-
-If `DISPLAY_WIDTH == DISPLAY_HEIGHT` (a single square panel, or a chain where `CHAIN_COLS ==
-CHAIN_ROWS` with a square panel), swapping width and height is a no-op, so forgetting to transpose
-the source buffer at `90°`/`270°` won't be visible — both the "correct" and the "wrong" buffer shape
-happen to be the same number. The mistake only shows up on non-square configurations (e.g. a `64×32`
-panel, or an asymmetric chain like `CHAIN_COLS=2, CHAIN_ROWS=1`), where it produces a visibly skewed
-or scrambled image, or — worse — out-of-bounds reads from the source buffer. If you've only tested
-rotation on a square panel so far, it's worth a quick test on a non-square one (or chain) before
-considering it verified.
+differently for chained arrays.
 
 ## Demo Effects
 

--- a/examples/rectangle.hpp
+++ b/examples/rectangle.hpp
@@ -17,8 +17,8 @@ public:
 
     void draw()
     {
-        constexpr int max_width = DISPLAY_WIDTH - 1;
-        constexpr int max_height = DISPLAY_HEIGHT - 1;
+        int max_width = bounds.w - 1;
+        int max_height = bounds.h - 1;
 
         // Draw four lines to form a rectangle around the screen. Each line has a unique color and ends one pixel short
         // of the edge of the panel so it doesn't 'interfere' with the next line.

--- a/hub75_demo.cpp
+++ b/hub75_demo.cpp
@@ -144,27 +144,27 @@ int main()
     // The following examples are animated. In the update function the color of the modified image data is ramped up to 10 bits and the image data is interwoven.
 
     // Create bouncing balls using pico_graphics functionality
-    BouncingBalls bouncingBalls(10, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    BouncingBalls bouncingBalls(10, HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
     // Create rotating antialiased line using pico_graphics functionality
-    Rotator rotator(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    Rotator rotator(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
     // Create analog clock using pico_graphics functionality
-    AnalogClock analogClock(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    AnalogClock analogClock(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
     // Create fire effect using pico_graphics functionality
-    FireEffect fireEffect = FireEffect(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    FireEffect fireEffect = FireEffect(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
-    HueValueSpectrum hueValueSpectrum = HueValueSpectrum(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    HueValueSpectrum hueValueSpectrum = HueValueSpectrum(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
-    PixelFill pixelFill = PixelFill(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    PixelFill pixelFill = PixelFill(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
     // Pico RAM is finite - due to your configuration of DISPLAY_WIDTH and DISPLAY_HEIGHT, BITPLANES, BALANCED_LIGHT_OUTPUT 
     // and SEPARATE_CIE_CHANNELS you have to select just a selection of demos! 
     
-    // GreyScaleStripes greyScaleStripes = GreyScaleStripes(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    // GreyScaleStripes greyScaleStripes = GreyScaleStripes(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
-    // Rectangle rectangle = Rectangle(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    // Rectangle rectangle = Rectangle(HUB75_SCREEN_WIDTH, HUB75_SCREEN_HEIGHT);
 
     // Cycle through the examples - move to next example every 15 seconds
     struct repeating_timer timer;

--- a/hub75_demo.cpp
+++ b/hub75_demo.cpp
@@ -105,7 +105,7 @@ bool skip_to_next_demo(__unused struct repeating_timer *t)
  */
 void core1_entry()
 {
-    create_hub75_driver(DISPLAY_WIDTH, DISPLAY_HEIGHT, PANEL_TYPE, INVERTED_STB);
+    create_hub75_driver();
     start_hub75_driver();
 
     // KEEP CORE 1 ALIVE — without this, Core 1's NVIC is torn down and DMA_IRQ_1 stops firing
@@ -132,7 +132,7 @@ void initialize()
     multicore_launch_core1(core1_entry); // Launch core 1 entry function - the Hub75 driver is doing its job there
 #else
     // Run hub75 on core0 - the Hub75 driver is doing its job here
-    create_hub75_driver(DISPLAY_WIDTH, DISPLAY_HEIGHT, PANEL_TYPE, INVERTED_STB);
+    create_hub75_driver();
     start_hub75_driver();
 #endif
 }

--- a/include/hub75.hpp
+++ b/include/hub75.hpp
@@ -350,8 +350,8 @@ enum Hub75ChainMode
     CHAIN_MODE_RASTER
 };
 
-void create_hub75_driver(uint w, uint h, uint pt, bool stb_inverted);
-void start_hub75_driver();
+void create_hub75_driver(void);
+void start_hub75_driver(void);
 void update_bgr(const uint8_t *src);
 #if USE_PICO_GRAPHICS == true
 void update(PicoGraphics const *graphics);

--- a/include/hub75.hpp
+++ b/include/hub75.hpp
@@ -275,13 +275,24 @@ static_assert(DISPLAY_ROTATION == 0 || DISPLAY_ROTATION == 90 || DISPLAY_ROTATIO
 
 // --- modifications below this line might imply changes in source code ---
 
-constexpr uint32_t matrix_panel_pixels = MATRIX_PANEL_WIDTH * MATRIX_PANEL_HEIGHT;
+namespace HUB75 {
+    // Total virtual display dimensions (derived — do not set manually)
+    constexpr uint32_t DISPLAY_WIDTH = MATRIX_PANEL_WIDTH * CHAIN_COLS;
+    constexpr uint32_t DISPLAY_HEIGHT = MATRIX_PANEL_HEIGHT * CHAIN_ROWS;
 
-// Total virtual display dimensions (derived — do not set manually)
-constexpr uint32_t DISPLAY_WIDTH = MATRIX_PANEL_WIDTH * CHAIN_COLS;
-constexpr uint32_t DISPLAY_HEIGHT = MATRIX_PANEL_HEIGHT * CHAIN_ROWS;
+    constexpr size_t TOTAL_PIXELS = DISPLAY_WIDTH * DISPLAY_HEIGHT;
+}
 
-constexpr size_t TOTAL_PIXELS = DISPLAY_WIDTH * DISPLAY_HEIGHT;
+// Define HUB75_SCREEN_WIDTH and HUB75_SCREEN_HEIGHT that follow screen rotation
+// settings. Use those to initialize drawing routines or allocate framebuffers.
+#if DISPLAY_ROTATION == 90 || DISPLAY_ROTATION == 270
+    #define HUB75_SCREEN_WIDTH (HUB75::DISPLAY_HEIGHT)
+    #define HUB75_SCREEN_HEIGHT (HUB75::DISPLAY_WIDTH)
+#else
+    #define HUB75_SCREEN_WIDTH (HUB75::DISPLAY_WIDTH)
+    #define HUB75_SCREEN_HEIGHT (HUB75::DISPLAY_HEIGHT)
+#endif
+
 
 #define LUT_MAPPING(COLOUR) pack_lut_rgb(COLOUR)
 #define LUT_MAPPING_RGB(R, G, B) pack_lut_rgb_(R, G, B)
@@ -331,17 +342,12 @@ namespace PanelConfig
     constexpr int32_t BITPLANE_STREAM_LENGTH = ((MATRIX_PANEL_WIDTH * CHAIN_ROWS * CHAIN_COLS) >> 1u) * ROWS_IN_PARALLEL;
 
     constexpr int32_t stride_row = MATRIX_PANEL_WIDTH * CHAIN_COLS;
-    constexpr int32_t stride_to_paired_row = SCAN_DEPTH * DISPLAY_WIDTH;
+    constexpr int32_t stride_to_paired_row = SCAN_DEPTH * HUB75::DISPLAY_WIDTH;
 }
-
-#if DISPLAY_ROTATION == 90 || DISPLAY_ROTATION == 270
-static_assert(DISPLAY_WIDTH == CHAIN_ROWS * MATRIX_PANEL_HEIGHT, "Width/height mismatch for rotated display");
-static_assert(DISPLAY_HEIGHT == CHAIN_COLS * MATRIX_PANEL_WIDTH, "Width/height mismatch for rotated display");
-#endif
 
 // Assert ROWSEL_N_PINS is set correctly
 static_assert(
-    (size_t)PanelConfig::SCAN_DEPTH * CHAIN_ROWS * CHAIN_COLS * MATRIX_PANEL_WIDTH * PanelConfig::ROWS_IN_PARALLEL == TOTAL_PIXELS,
+    (size_t)PanelConfig::SCAN_DEPTH * CHAIN_ROWS * CHAIN_COLS * MATRIX_PANEL_WIDTH * PanelConfig::ROWS_IN_PARALLEL == HUB75::TOTAL_PIXELS,
     "rgb_buffer total writes must equal TOTAL_PIXELS — check ROWSEL_N_PINS vs MATRIX_PANEL_HEIGHT, and CHAIN_ROWS/CHAIN_COLS");
 
 enum Hub75ChainMode
@@ -364,4 +370,12 @@ void setIntensity(float intensity, bool linear_brightness_control);
 #if defined(HUB75_MULTIPLEX_2_ROWS)
 static_assert(MATRIX_PANEL_HEIGHT == 2 * PanelConfig::SCAN_DEPTH, "HUB75_MULTIPLEX_2_ROWS requires two-row multiplexing");
 #endif
-static_assert(DISPLAY_WIDTH % 2 == 0, "HUB75 bitstream expects even pixel pairs");
+static_assert(HUB75::DISPLAY_WIDTH % 2 == 0, "HUB75 bitstream expects even pixel pairs");
+
+#if DISPLAY_ROTATION == 90 || DISPLAY_ROTATION == 270
+static_assert(HUB75_SCREEN_WIDTH == CHAIN_ROWS * MATRIX_PANEL_HEIGHT, "Width/height mismatch for rotated display");
+static_assert(HUB75_SCREEN_HEIGHT == CHAIN_COLS * MATRIX_PANEL_WIDTH, "Width/height mismatch for rotated display");
+#else
+static_assert(HUB75_SCREEN_HEIGHT == CHAIN_ROWS * MATRIX_PANEL_HEIGHT, "Width/height mismatch for rotated display");
+static_assert(HUB75_SCREEN_WIDTH == CHAIN_COLS * MATRIX_PANEL_WIDTH, "Width/height mismatch for rotated display");
+#endif

--- a/include/hub75.hpp
+++ b/include/hub75.hpp
@@ -95,14 +95,14 @@ static_assert(CHAIN_COLS >= 1, "CHAIN_COLS must be >= 1");
 // Example:
 // The P3-64*64-32S-V2.0 is a standard Hub75 panel with two rows multiplexed, so define HUB75_MULTIPLEX_2_ROWS should be correct
 //
-// #define HUB75                       // default - two rows lit simultaneously
+// #define HUB75_DEFAULT               // default - two rows lit simultaneously
 // #define HUB75_P10_3535_16X32_4S     // four rows lit simultaneously (can be defined via CMake)
 // #define HUB75_P3_1415_16S_64X64_S31 // four rows lit simultaneously
 //
-// Default to HUB75 if no multiplexing mode is defined
+// Default to HUB75_DEFAULT if no multiplexing mode is defined
 // Only define default if none of the mapping modes are already defined
-#if !defined(HUB75) && !defined(HUB75_P10_3535_16X32_4S) && !defined(HUB75_P3_1415_16S_64X64_S31)
-#define HUB75 // two or four rows lit simultaneously
+#if !defined(HUB75_DEFAULT) && !defined(HUB75_P10_3535_16X32_4S) && !defined(HUB75_P3_1415_16S_64X64_S31)
+#define HUB75_DEFAULT // two or four rows lit simultaneously
 #endif
 
 // If panel type FM6126A or panel type RUL6024 is selected, an initialisation sequence is sent to the panel

--- a/src/hub75.cpp
+++ b/src/hub75.cpp
@@ -652,10 +652,8 @@ void setup_bitplane_stream_irq()
  * LED matrix display. It initializes DMA channels, PIO state machines, and
  * interrupt handlers.
  *
- * @param w Width of the HUB75 display in pixels.
- * @param h Height of the HUB75 display in pixels.
  */
-void create_hub75_driver(uint w, uint h, uint panel_type = PANEL_TYPE, bool inverted_stb = INVERTED_STB)
+void create_hub75_driver(void)
 {
     dma_buffer = frame_buffer1;
     frame_buffer = frame_buffer2;
@@ -665,16 +663,13 @@ void create_hub75_driver(uint w, uint h, uint panel_type = PANEL_TYPE, bool inve
 
     hub75_timing_init(&hub75_timing_config, clock_get_hz(clk_sys), SM_CLOCKDIV);
 
-    if (panel_type == PANEL_FM6126A)
-    {
+    #if PANEL_TYPE == PANEL_FM6126A
         FM6126A_setup();
-    }
-    else if (panel_type == PANEL_RUL6024)
-    {
+    #elif PANEL_TYPE == PANEL_RUL6024
         RUL6024_setup();
-    }
+    #endif
 
-    configure_pio(inverted_stb);
+    configure_pio(INVERTED_STB);
     setup_dma_transfers();
     setup_bitplane_creation();
     setup_display_irq();
@@ -689,7 +684,7 @@ void create_hub75_driver(uint w, uint h, uint panel_type = PANEL_TYPE, bool inve
  * for the Output Enable finished DMA channel and the read address for pixel data.
  * It ensures that the display begins processing frames.
  */
-void start_hub75_driver()
+void start_hub75_driver(void)
 {
     dma_row_cmd_buffer = row_cmd_buffer2;
     row_cmd_buffer = row_cmd_buffer1;

--- a/src/hub75.cpp
+++ b/src/hub75.cpp
@@ -1026,7 +1026,7 @@ __attribute__((optimize("unroll-loops"))) void update(
 
     __attribute__((aligned(4))) uint32_t const *src = static_cast<uint32_t const *>(graphics->frame_buffer);
 
-#if defined(HUB75)
+#if defined(HUB75_DEFAULT)
 #if CHAIN_COLS == 1 && CHAIN_ROWS == 1
     // HUB75_MULTIPLEX_2_ROWS — single panel, with display rotation support.
 
@@ -1382,7 +1382,7 @@ __attribute__((optimize("unroll-loops"))) void update(
  */
 __attribute__((optimize("unroll-loops"))) void update_bgr(const uint8_t *src)
 {
-#if defined(HUB75)
+#if defined(HUB75_DEFAULT)
 #if CHAIN_COLS == 1 && CHAIN_ROWS == 1
     // HUB75_MULTIPLEX_2_ROWS — single panel, with display rotation support (BGR byte layout).
     //

--- a/src/hub75.cpp
+++ b/src/hub75.cpp
@@ -17,6 +17,10 @@
 
 #include "cie.hpp"
 
+using HUB75::DISPLAY_WIDTH;
+using HUB75::DISPLAY_HEIGHT;
+using HUB75::TOTAL_PIXELS;
+
 // Frame buffer for the HUB75 matrix - memory area where pixel data is stored
 uint8_t *frame_buffer; ///< Back buffer — written by bitplane builder (read_chan_handler)
 uint8_t *dma_buffer;   ///< Front buffer — read by pixel_chan DMA → panel streamer


### PR DESCRIPTION
To minimize errors when defining the width and height of physical and logical displays and corresponding framebuffers, introduce new global `HUB75_SCREEN_WIDTH` and `HUB75_SCREEN_HEIGHT`. Those defines are rotation-aware and can be used to initialize drawing routines or framebuffer memory. Changing the `DISPLAY_ROTATION` will now automagically rotate all demos as specified.

In addition to this change, the initialization API can be simplified a little by solely depending on global `#defines` instead of local parameters.