### PR TITLE
Pack row address and t_addr + t_oe wait loops in hub75_row PIO programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,7 @@ target_compile_definitions(hub75_demo PRIVATE
     CCM_GB_SHIFT=7              # CCM Cross-channel mixing - mix ~0.8% blue into the green channel
     DISPLAY_ROTATION=0          # display rotation - valid values 0, 90, 180, 270 
     BASE_LATCH_NS=80            # wait time in nano-seconds to stabilise latch
-    BASE_ADDR_NS=120            # wait time in nano-seconds to stabilise row addressing
-    BASE_OE_NS=40               # pre-Oe guard wait time in nano-seconds (prevents ghost flashes)
+    BASE_ADDR_NS=160            # wait time in nano-seconds to stabilise row addressing
     HUB75_MULTICORE=true        # use core1 for the hub75 driver
     FRAME_RATE=false            # for testing and debugging purpose only: output frame rate information (printf) in monitor - set to `false` for production
 )

--- a/README.md
+++ b/README.md
@@ -381,8 +381,7 @@ The table below lists every configurable preprocessor define, its **default valu
 | `CCM_RG_SHIFT` | `6` | CCM Cross-channel mixing - mix ~1.6% green into the red channel. |
 | `CCM_GB_SHIFT`| `7` |  CCM Cross-channel mixing - mix ~0.8% blue into the green channel. |
 | `BASE_LATCH_NS` | `80` | Wait time in nano-seconds to stabilise latch. |
-| `BASE_ADDR_NS` | `120` | Wait time in nano-seconds to stabilise row addressing. |
-| `BASE_OE_NS` | `40` | Pre-Oe guard wait time in nano-seconds (prevents ghost flashes). |
+| `BASE_ADDR_NS` | `160` | Wait time in nano-seconds to stabilise row addressing. |
 | `HUB75_MULTICORE` | `true` | Set to `true` to run the hub75 driver on core 1, freeing core 0 for application logic. |
 | `FRAME_RATE` | `false` | For testing and debugging purpose only: output frame rate information (printf) in monitor - set to `false` for production. |
 
@@ -431,8 +430,7 @@ target_compile_definitions(hub75 PRIVATE
     CCM_RG_SHIFT=6              # CCM Cross-channel mixing - mix ~1.6% green into the red channel
     CCM_GB_SHIFT=7              # CCM Cross-channel mixing - mix ~0.8% blue into the green channel
     BASE_LATCH_NS=80            # wait time in nano-seconds to stabilise latch
-    BASE_ADDR_NS=120            # wait time in nano-seconds to stabilise row addressing
-    BASE_OE_NS=40               # pre-Oe guard wait time in nano-seconds (prevents ghost flashes)
+    BASE_ADDR_NS=160            # wait time in nano-seconds to stabilise row addressing
     HUB75_MULTICORE=true        # use core1 for the hub75 driver
     FRAME_RATE=false            # for testing and debugging purpose only: output frame rate information (printf) in monitor - set to `false` for production
 )
@@ -793,7 +791,7 @@ Building on the DMA/PIO foundation, Version 3.0 adds:
 - **Colour Correction Matrix (CCM)** — Six integer-shift cross-terms correct spectral bleed
   between channels. Zero floating-point cost; off by default (`shift = 31`).
 - **Anti-ghosting & Settling Delays** — Configurable nano-second timing guards
-  (`BASE_LATCH_NS`, `BASE_ADDR_NS`, `BASE_OE_NS`) around latch, address, and OE transitions
+  (`BASE_LATCH_NS`, `BASE_ADDR_NS`) around latch and address transitions
   eliminate ghosting and edge glimmer at high clock speeds.
 - **Double-buffering for both frame and command buffers** — Tear-free updates; the
   `row_cmd_buffer` is only swapped when brightness actually changes.
@@ -1708,8 +1706,7 @@ The table below lists every configurable preprocessor define, its **default valu
 | `CCM_RG_SHIFT` | `6` | CCM Cross-channel mixing - mix ~1.6% green into the red channel. |
 | `CCM_GB_SHIFT`| `7` |  CCM Cross-channel mixing - mix ~0.8% blue into the green channel. |
 | `BASE_LATCH_NS` | `80` | Wait time in nano-seconds to stabilise latch. |
-| `BASE_ADDR_NS` | `120` | Wait time in nano-seconds to stabilise row addressing. |
-| `BASE_OE_NS` | `40` | Pre-Oe guard wait time in nano-seconds (prevents ghost flashes). |
+| `BASE_ADDR_NS` | `160` | Wait time in nano-seconds to stabilise row addressing. |
 | `HUB75_MULTICORE` | `true` | Set to `true` to run the hub75 driver on core 1, freeing core 0 for application logic. |
 | `FRAME_RATE` | `false` | For testing and debugging purpose only: output frame rate information (printf) in monitor - set to `false` for production. |
 
@@ -2475,8 +2472,7 @@ target_compile_definitions(hub75 PRIVATE
     SEPARATE_CIE_CHANNELS=true
     HUB75_MULTICORE=true
     BASE_LATCH_NS=80
-    BASE_ADDR_NS=120
-    BASE_OE_NS=40
+    BASE_ADDR_NS=160
     FRAME_RATE=false                # set to true only for debugging
 )
 ```
@@ -2532,8 +2528,7 @@ target_compile_definitions(hub75 PRIVATE
     SEPARATE_CIE_CHANNELS=true
     HUB75_MULTICORE=true
     BASE_LATCH_NS=80
-    BASE_ADDR_NS=120
-    BASE_OE_NS=40
+    BASE_ADDR_NS=160
     FRAME_RATE=false
 )
 ```
@@ -2605,8 +2600,7 @@ target_compile_definitions(hub75 PRIVATE
     SEPARATE_CIE_CHANNELS=true
     HUB75_MULTICORE=true
     BASE_LATCH_NS=100               # slightly wider timing margins for outdoor panel
-    BASE_ADDR_NS=200
-    BASE_OE_NS=60
+    BASE_ADDR_NS=260
     FRAME_RATE=false                # set to true only for debugging
 )
 ```
@@ -2667,8 +2661,7 @@ target_compile_definitions(hub75 PRIVATE
     SEPARATE_CIE_CHANNELS=true
     HUB75_MULTICORE=true
     BASE_LATCH_NS=80
-    BASE_ADDR_NS=120
-    BASE_OE_NS=40
+    BASE_ADDR_NS=160
     FRAME_RATE=false
 )
 ```
@@ -2727,8 +2720,7 @@ target_compile_definitions(hub75 PRIVATE
     SEPARATE_CIE_CHANNELS=true
     HUB75_MULTICORE=true
     BASE_LATCH_NS=80
-    BASE_ADDR_NS=120
-    BASE_OE_NS=40
+    BASE_ADDR_NS=160
     FRAME_RATE=false
 )
 ```

--- a/include/hub75.hpp
+++ b/include/hub75.hpp
@@ -263,10 +263,6 @@ static_assert(DISPLAY_ROTATION == 0 || DISPLAY_ROTATION == 90 || DISPLAY_ROTATIO
 #define BASE_ADDR_NS 120
 #endif
 
-#ifndef BASE_OE_NS
-#define BASE_OE_NS 40
-#endif
-
 // Frame rate
 // Use only for testing or debugging
 #ifndef FRAME_RATE

--- a/include/hub75.hpp
+++ b/include/hub75.hpp
@@ -260,7 +260,7 @@ static_assert(DISPLAY_ROTATION == 0 || DISPLAY_ROTATION == 90 || DISPLAY_ROTATIO
 #endif
 
 #ifndef BASE_ADDR_NS
-#define BASE_ADDR_NS 120
+#define BASE_ADDR_NS 160
 #endif
 
 // Frame rate

--- a/src/hub75.cpp
+++ b/src/hub75.cpp
@@ -34,11 +34,13 @@ uint8_t *dma_buffer;   ///< Front buffer — read by pixel_chan DMA → panel st
  *
  * Memory layout (packed, DMA streamed):
  * -------------------------------------
- * [0] row_address : Row select (A..E lines)
- * [1] t_addr      : Address setup delay (PIO cycles)
- * [2] t_oe        : OE guard delay before activation
- * [3] lit_cycles  : OE active duration (LEDs ON)
- * [4] dark_cycles : OE inactive duration (LEDs OFF)
+ * [0] addr_delay  : bits[4:0] row_address (A..E lines), bits[31:5] t_addr (PIO cycles)
+ * [1] lit_cycles  : OE active duration (LEDs ON)
+ * [2] dark_cycles : OE inactive duration (LEDs OFF)
+ *
+ * addr_delay is packed this way because the hub75_row PIO program consumes
+ * it as one 32-bit DMA word: `out pins, 5` peels off the row address, then
+ * `out x, 27` takes the rest straight into the address-settle wait loop
  *
  * Constraints:
  * ------------
@@ -49,9 +51,7 @@ uint8_t *dma_buffer;   ///< Front buffer — read by pixel_chan DMA → panel st
  */
 struct row_cmd_t
 {
-    uint32_t row_address; ///< 5-bit row select; selects which pair of rows to drive
-    uint32_t t_addr;      ///< wait cycles for row address to stabilise (bitplane dependent)
-    uint32_t t_oe;        ///< wait cycles before OE enabled (bitplane dependent)
+    uint32_t addr_delay;  ///< packed: bits[4:0]=row_address, bits[31:5]=t_addr (address-settling delay, bitplane dependent)
     uint32_t lit_cycles;  ///< OEn ON  duration for this bit plane, scaled by brightness
     uint32_t dark_cycles; ///< OEn OFF duration = full BCM period - lit_cycles
 
@@ -114,12 +114,10 @@ static void setup_dma_transfers();
  * 1. Physical domain (ns):
  *    - latch_ns
  *    - addr_ns
- *    - oe_ns
  *
  * 2. Derived domain (PIO cycles):
  *    - latch_cycles
  *    - addr_cycles
- *    - oe_cycles
  *
  * Conversion:
  * -----------
@@ -135,12 +133,10 @@ typedef struct
     // --- Physical timing (configuration level) ---
     uint32_t latch_ns; // STB settle
     uint32_t addr_ns;  // Address settle
-    uint32_t oe_ns;    // OE guard
 
     // --- Derived PIO-cycles (Runtime) ---
     uint16_t latch_cycles;
     uint16_t addr_cycles;
-    uint16_t oe_cycles;
 
     // --- System parameter (used for re-scaling) ---
     float clk_sys_hz;
@@ -268,14 +264,12 @@ static inline void hub75_timing_recompute(hub75_timing_config_t *cfg)
 {
     cfg->latch_cycles = ns_to_pio_cycles(cfg->latch_ns, cfg->clk_sys_hz, cfg->clkdiv);
     cfg->addr_cycles = ns_to_pio_cycles(cfg->addr_ns, cfg->clk_sys_hz, cfg->clkdiv);
-    cfg->oe_cycles = ns_to_pio_cycles(cfg->oe_ns, cfg->clk_sys_hz, cfg->clkdiv);
 }
 
-void hub75_set_timing_ns(hub75_timing_config_t *cfg, uint32_t latch_ns, uint32_t addr_ns, uint32_t oe_ns)
+void hub75_set_timing_ns(hub75_timing_config_t *cfg, uint32_t latch_ns, uint32_t addr_ns)
 {
     cfg->latch_ns = latch_ns;
     cfg->addr_ns = addr_ns;
-    cfg->oe_ns = oe_ns;
 
     hub75_timing_recompute(cfg);
 }
@@ -284,7 +278,6 @@ void hub75_timing_init(hub75_timing_config_t *cfg, float clk_sys_hz, float clkdi
 {
     cfg->latch_ns = BASE_LATCH_NS;
     cfg->addr_ns = BASE_ADDR_NS;
-    cfg->oe_ns = BASE_OE_NS;
 
     cfg->clk_sys_hz = clk_sys_hz;
     cfg->clkdiv = clkdiv;
@@ -358,10 +351,11 @@ void hub75_build_row_cmd_buffer(uint32_t brightness_fp)
 
         for (uint32_t row = 0; row < PanelConfig::SCAN_DEPTH; ++row)
         {
+            uint32_t t_addr = hub75_timing_config.addr_cycles + (bp >> 1); // address settle
             row_cmd_t *cmd = &row_cmd_buffer[idx++];
-            cmd->row_address = encode_row_address(row);
-            cmd->t_addr = hub75_timing_config.addr_cycles + (bp >> 1); // very effective
-            cmd->t_oe = hub75_timing_config.oe_cycles + (bp >> 2);     // fine tuning
+            // low 5 bits = row address (hub75_row PIO consumes exactly 5 bits via `out pins, 5`),
+            // upper 27 bits = t_addr, taken by the following `out x, 27`
+            cmd->addr_delay = (t_addr << 5) | (encode_row_address(row) & 0x1Fu);
             cmd->lit_cycles = lit_cycles;
             cmd->dark_cycles = dark_cycles;
         }

--- a/src/hub75.pio
+++ b/src/hub75.pio
@@ -21,7 +21,7 @@
 ;   - Trigger prefetch of next row while current row is displayed
 ;
 ; Data format (via DMA, 3 words per row/bit-plane):
-;   1. row_address (5-bit used)
+;   1. addr_delay  (packed: bits[4:0]=row_address, bits[31:5]=t_addr delay, PIO cycles)
 ;   2. lit_cycles  (OEn active → LEDs ON)
 ;   3. dark_cycles (OEn inactive → LEDs OFF)
 ;
@@ -64,34 +64,23 @@ wait_latch_settle:
     irq nowait 1        side 0b10
 
     ; -------------------------------------------------------------------------
-    ; 5. ADDRESSING: set row AFTER latch is fully stable
+    ; 5. ADDRESSING + t_addr: set row AFTER latch is fully stable, then
+    ;    consume the rest of the same packed word as the address-settle delay
     ; -------------------------------------------------------------------------
-    out pins, 5         side 0b10   ; Output A–E row address
-    out null, 27        side 0b10   ; Discard unused bits
-
-    ; -------------------------------------------------------------------------
-    ; 6. LOAD t_addr - Stabilise row addressing
-    ; -------------------------------------------------------------------------
-    out x, 32           side 0b10   ; load t_addr into X register
+    out pins, 5          side 0b10   ; Output A–E row address (low 5 bits of packed word)
+    out x, 27            side 0b10   ; load t_addr delay (upper 27 bits) into X register
 addr_wait:
-    jmp x-- addr_wait   side 0b10
+    jmp x-- addr_wait side 0b10
 
     ; -------------------------------------------------------------------------
-    ; 7. LOAD t_oe_guard - PRE-OE GUARD (prevents ghost flashes)
-    ; -------------------------------------------------------------------------
-    out x, 32           side 0b10   ; load t_oe into X register
-oe_guard_wait:
-    jmp x-- oe_guard_wait side 0b10
-
-    ; -------------------------------------------------------------------------
-    ; 8. DISPLAY (BCM ON phase)
+    ; 6. DISPLAY (BCM ON phase)
     ; -------------------------------------------------------------------------
     out x, 32           side 0b10   ; load lit_cycles
 lit_loop:
     jmp x-- lit_loop    side 0b00   ; OE=0 → LEDs ON
 
     ; -------------------------------------------------------------------------
-    ; 9. BLANKING (BCM OFF phase)
+    ; 7. BLANKING (BCM OFF phase)
     ; -------------------------------------------------------------------------
     out x, 32           side 0b10   ; load dark_cycles
 dark_loop:
@@ -173,34 +162,23 @@ wait_latch_settle:
     irq nowait 1        side 0b11
 
     ; -------------------------------------------------------------------------
-    ; 5. ADDRESSING: set row AFTER latch is fully stable
+    ; 5. ADDRESSING + t_addr: set row AFTER latch is fully stable, then
+    ;    consume the rest of the same packed word as the address-settle delay
     ; -------------------------------------------------------------------------
-    out pins, 5         side 0b11   ; Output A–E row address
-    out null, 27        side 0b11   ; Discard unused bits
-
-    ; -------------------------------------------------------------------------
-    ; 6. LOAD t_addr - Stabilise row addressing
-    ; -------------------------------------------------------------------------
-    out x, 32           side 0b11   ; load t_addr into X register
+    out pins, 5          side 0b11   ; Output A–E row address (low 5 bits of packed word)
+    out x, 27            side 0b11   ; load t_addr delay (upper 27 bits) into X register
 addr_wait:
-    jmp x-- addr_wait   side 0b11
+    jmp x-- addr_wait side 0b11
 
     ; -------------------------------------------------------------------------
-    ; 7. LOAD t_oe_guard - PRE-OE GUARD (prevents ghost flashes)
-    ; -------------------------------------------------------------------------
-    out x, 32           side 0b11   ; load t_oe into X register
-oe_guard_wait:
-    jmp x-- oe_guard_wait side 0b11
-
-    ; -------------------------------------------------------------------------
-    ; 8. DISPLAY (BCM ON phase)
+    ; 6. DISPLAY (BCM ON phase)
     ; -------------------------------------------------------------------------
     out x, 32           side 0b11   ; load lit_cycles
 lit_loop:
     jmp x-- lit_loop    side 0b01   ; OE=0 → LEDs ON
 
     ; -------------------------------------------------------------------------
-    ; 9. BLANKING (BCM OFF phase)
+    ; 7. BLANKING (BCM OFF phase)
     ; -------------------------------------------------------------------------
     out x, 32           side 0b11   ; load dark_cycles
 dark_loop:


### PR DESCRIPTION
row_address (5 bits) can be combined together with t_addr (address settle) and t_oe (OE guard). The maximum possible delay will be limited to just 27 bits, but this should still be plenty of time.

The PIO program handled both wait times exactly the same and one after the other, so combining them is an easy step: just add the times before passing the value to PIO. This saves two PIO instructions and four bytes per row_cmd_t.

Packing the 5 bit address into the same 4-byte integer used for the delay allows to remove one additional PIO instruction and saves another 4 bytes per row_cmd_t.